### PR TITLE
Update go.mod versions

### DIFF
--- a/hello-world/go.mod
+++ b/hello-world/go.mod
@@ -1,3 +1,3 @@
 module encore.app
 
-go 1.15
+go 1.18

--- a/sql-database/go.mod
+++ b/sql-database/go.mod
@@ -1,5 +1,5 @@
 module encore.app
 
-go 1.15
+go 1.18
 
-require encore.dev v0.7.0
+require encore.dev v1.1.0

--- a/sql-database/go.sum
+++ b/sql-database/go.sum
@@ -1,2 +1,2 @@
-encore.dev v0.7.0 h1:zrYU21r6DfB0ftQFgS9yh3o6KrJg7MV4kZGY4fkv+is=
-encore.dev v0.7.0/go.mod h1:eKOQ6G72uYiV0DbDJam6BB07KsIfvpqT3cQfadCShao=
+encore.dev v1.1.0 h1:OXAOw441M7wAllwTH2EadOWLThKzLg48bGSs44Kdd3U=
+encore.dev v1.1.0/go.mod h1:eKOQ6G72uYiV0DbDJam6BB07KsIfvpqT3cQfadCShao=

--- a/trello-clone/go.mod
+++ b/trello-clone/go.mod
@@ -1,8 +1,8 @@
 module encore.app
 
-go 1.15
+go 1.18
 
 require (
-	encore.dev v0.7.0
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	encore.dev v1.1.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )

--- a/trello-clone/go.sum
+++ b/trello-clone/go.sum
@@ -1,4 +1,6 @@
-encore.dev v0.7.0 h1:zrYU21r6DfB0ftQFgS9yh3o6KrJg7MV4kZGY4fkv+is=
-encore.dev v0.7.0/go.mod h1:eKOQ6G72uYiV0DbDJam6BB07KsIfvpqT3cQfadCShao=
+encore.dev v1.1.0 h1:OXAOw441M7wAllwTH2EadOWLThKzLg48bGSs44Kdd3U=
+encore.dev v1.1.0/go.mod h1:eKOQ6G72uYiV0DbDJam6BB07KsIfvpqT3cQfadCShao=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/websocket-echo-server/go.mod
+++ b/websocket-echo-server/go.mod
@@ -1,8 +1,8 @@
 module encore.app
 
-go 1.15
+go 1.18
 
 require (
-	encore.dev v0.7.0
-	github.com/gorilla/websocket v1.4.2
+	encore.dev v1.1.0
+	github.com/gorilla/websocket v1.5.0
 )

--- a/websocket-echo-server/go.sum
+++ b/websocket-echo-server/go.sum
@@ -1,4 +1,6 @@
-encore.dev v0.7.0 h1:zrYU21r6DfB0ftQFgS9yh3o6KrJg7MV4kZGY4fkv+is=
-encore.dev v0.7.0/go.mod h1:eKOQ6G72uYiV0DbDJam6BB07KsIfvpqT3cQfadCShao=
+encore.dev v1.1.0 h1:OXAOw441M7wAllwTH2EadOWLThKzLg48bGSs44Kdd3U=
+encore.dev v1.1.0/go.mod h1:eKOQ6G72uYiV0DbDJam6BB07KsIfvpqT3cQfadCShao=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=


### PR DESCRIPTION
This commit brings the `encore.dev` version in the examples up to the current version