### PR TITLE
Add sendgrid bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The [bits](bits) sub-folder contains reusable code samples that can be copied di
 |-------------------------------|-------------------------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------------|
 | [elevenlabs](bits/elevenlabs) | Getting text to speech from [ElevenLabs](https://elevenlabs.io/) generative voice AI | APIs, Secrets | [ElevenLabs API key](https://docs.elevenlabs.io/api-reference/quick-start/authentication) |
 | [pexels](bits/pexels)         | Searching and retrieving photos and videos from [Pexels](https://www.pexels.com/)   | APIs, Secrets | [Pexels API key](https://www.pexels.com/api/)     |
+| [sendgrid](bits/sendgrid)         | Asynchronous sending emails via [SendGrid](https://sendgrid.com/)   | APIs, Secrets, Pub/Sub | [SendGrid API key](https://docs.sendgrid.com/ui/account-and-settings/api-keys)     |
 
 ## Contribute your templates
 

--- a/bits/sendgrid/README.md
+++ b/bits/sendgrid/README.md
@@ -35,8 +35,14 @@ The `sendgrid` package contains the following endpoints:
 ```bash
 curl 'http://localhost:4000/sendgrid' \
 -d '{
-    "from": "sender@example.com",
-    "to": "recipient@example.com",
+    "from": {
+        "name": "Sender",
+        "email": "sender@example.com"
+    },
+    "to": {
+        "name": "Recipient",
+        "email": "recipient@example.com"
+    },
     "subject": "Sending with Twilio SendGrid is Fun",
     "text": "and easy to do anywhere, even with Encore",
     "html": "<strong>and easy to do anywhere, even with Encore</strong>"

--- a/bits/sendgrid/README.md
+++ b/bits/sendgrid/README.md
@@ -14,10 +14,16 @@ You will need an [API key from SendGrid](https://docs.sendgrid.com/ui/account-an
 Once you have the API key, set it as an Encore secret using the name `SendGridAPIKey`:
 
 ```bash
-$ encore secret set --type dev,prod,local,pr SendGridAPIKey
+# It is good practice to separate API keys for development and production environments
+$ encore secret set --dev SendGridAPIKey
+Enter secret value: *****
+Successfully updated development secret SendGridAPIKey.
+# To set the API key for production environment
+$ encore secret set --prod SendGridAPIKey
 Enter secret value: *****
 Successfully updated development secret SendGridAPIKey.
 ```
+> Please note that emails will only be sent in the production environment to avoid spending your email sending limits.
 
 ## Endpoints 
 

--- a/bits/sendgrid/README.md
+++ b/bits/sendgrid/README.md
@@ -29,20 +29,14 @@ Successfully updated development secret SendGridAPIKey.
 
 The `sendgrid` package contains the following endpoints:
 
-* `sendgrid.Send` - Sends an email using the SendGrid API.
+* `sendgrid.Send` - Send publishes an email to PubSub for further asynchronous sending using the SendGrid API.
 
 #### Using the API
 ```bash
 curl 'http://localhost:4000/sendgrid' \
 -d '{
-    "from": {
-        "name": "Sender",
-        "address": "sender@example.com"
-    },
-    "to": {
-        "name": "Recipient",
-        "address": "recipient@example.com"
-    },
+    "from": "sender@example.com",
+    "to": "recipient@example.com",
     "subject": "Sending with Twilio SendGrid is Fun",
     "text": "and easy to do anywhere, even with Encore",
     "html": "<strong>and easy to do anywhere, even with Encore</strong>"

--- a/bits/sendgrid/README.md
+++ b/bits/sendgrid/README.md
@@ -1,0 +1,50 @@
+# SendGrid: Email Delivery
+
+This is an Encore package for asynchronous sending emails via [SendGrid](https://sendgrid.com/) using Pub/Sub and the ability to flexibly configure concurrency and retry policies.
+
+## Installation
+
+1. Copy over the `sendgrid` package directory to your Encore application.
+2. Sync your project dependencies by running `go mod tidy`.
+
+## SendGrid API Key
+
+You will need an [API key from SendGrid](https://docs.sendgrid.com/ui/account-and-settings/api-keys) to use this package. You can get one by signing up for a free account at https://sendgrid.com/.
+
+Once you have the API key, set it as an Encore secret using the name `SendGridAPIKey`:
+
+```bash
+$ encore secret set --type dev,prod,local,pr SendGridAPIKey
+Enter secret value: *****
+Successfully updated development secret SendGridAPIKey.
+```
+
+## Endpoints 
+
+The `sendgrid` package contains the following endpoints:
+
+* `sendgrid.Send` - Sends an email using the SendGrid API.
+
+#### Using the API
+```bash
+curl 'http://localhost:4000/sendgrid' \
+-d '{
+    "from": {
+        "name": "Sender",
+        "address": "sender@example.com"
+    },
+    "to": {
+        "name": "Recipient",
+        "address": "recipient@example.com"
+    },
+    "subject": "Sending with Twilio SendGrid is Fun",
+    "text": "and easy to do anywhere, even with Encore",
+    "html": "<strong>and easy to do anywhere, even with Encore</strong>"
+}'
+```
+
+## Learn More
+
+- [Encore Documentation](https://encore.dev/docs)
+- [Pub/Sub Documentation](https://encore.dev/docs/primitives/pubsub)
+- [SendGrid Documentation](https://docs.sendgrid.com/)

--- a/bits/sendgrid/sendgrid.go
+++ b/bits/sendgrid/sendgrid.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"encore.dev"
 	"encore.dev/beta/errs"
 	"encore.dev/pubsub"
 	"encore.dev/rlog"
@@ -18,12 +19,12 @@ var secrets struct {
 
 type SendParams struct {
 	From struct {
-		Name    string `json:"name,omitempty"`
-		Address string `json:"address"`
+		Name  string `json:"name,omitempty"`
+		Email string `json:"email"`
 	} `json:"from"`
 	To struct {
-		Name    string `json:"name,omitempty"`
-		Address string `json:"address"`
+		Name  string `json:"name,omitempty"`
+		Email string `json:"email"`
 	} `json:"to"`
 	Subject string `json:"subject"`
 	Text    string `json:"text"`
@@ -37,12 +38,12 @@ type SendResponse struct {
 // Send sends an email using the SendGrid API.
 // https://docs.sendgrid.com/api-reference/mail-send/mail-send
 //
-//encore:api public method=POST path=/sendgrid
+//encore:api private method=POST path=/sendgrid
 func Send(ctx context.Context, params *SendParams) (*SendResponse, error) {
 	// Preparing the data to create an email event ready to be sent
 	event := &EmailPreparedEvent{
-		From:             *mail.NewEmail(params.From.Name, params.From.Address),
-		To:               *mail.NewEmail(params.To.Name, params.To.Address),
+		From:             *mail.NewEmail(params.From.Name, params.From.Email),
+		To:               *mail.NewEmail(params.To.Name, params.To.Email),
 		Subject:          params.Subject,
 		PlainTextContent: params.Text,
 		HTMLContent:      params.Html,
@@ -83,6 +84,15 @@ var _ = pubsub.NewSubscription(
 func sendEmail(ctx context.Context, event *EmailPreparedEvent) error {
 	// Creating an email
 	message := mail.NewSingleEmail(&event.From, event.Subject, &event.To, event.PlainTextContent, event.HTMLContent)
+	// Skipping sending an email in a non-production environment
+	if encore.Meta().Environment.Type != encore.EnvProduction {
+		rlog.Info(
+			"email sending was skipped in a non-production environment.",
+			"env:", encore.Meta().Environment.Type,
+			"message:", message)
+		return nil
+	}
+
 	// Creating a client using an API key
 	client := sendgrid.NewSendClient(secrets.SendGridAPIKey)
 	// Sending and error handling

--- a/bits/sendgrid/sendgrid.go
+++ b/bits/sendgrid/sendgrid.go
@@ -92,7 +92,7 @@ func sendEmail(ctx context.Context, event *EmailPreparedEvent) error {
 	// Sending and error handling
 	response, err := client.SendWithContext(ctx, email)
 	if err != nil {
-		rlog.Error(err.Error())
+		rlog.Error("failed sending email", "err", err)
 		return err
 	}
 

--- a/bits/sendgrid/sendgrid.go
+++ b/bits/sendgrid/sendgrid.go
@@ -18,32 +18,26 @@ var secrets struct {
 }
 
 type SendParams struct {
-	From struct {
-		Name  string `json:"name,omitempty"`
-		Email string `json:"email"`
-	} `json:"from"`
-	To struct {
-		Name  string `json:"name,omitempty"`
-		Email string `json:"email"`
-	} `json:"to"`
+	From    string `json:"form"` // sender email address
+	To      string `json:"to"`   // recipient email address
 	Subject string `json:"subject"`
 	Text    string `json:"text"`
 	Html    string `json:"html"`
 }
 
 type SendResponse struct {
-	MessageID string `json:"message_id"`
+	MessageID string `json:"message_id"` // Message ID in PubSub
 }
 
-// Send sends an email using the SendGrid API.
+// Send publishes an email to PubSub for further asynchronous sending using the SendGrid API.
 // https://docs.sendgrid.com/api-reference/mail-send/mail-send
 //
 //encore:api private method=POST path=/sendgrid
 func Send(ctx context.Context, params *SendParams) (*SendResponse, error) {
 	// Preparing the data to create an email event ready to be sent
 	event := &EmailPreparedEvent{
-		From:             *mail.NewEmail(params.From.Name, params.From.Email),
-		To:               *mail.NewEmail(params.To.Name, params.To.Email),
+		From:             mail.Email{Address: params.From},
+		To:               mail.Email{Address: params.To},
 		Subject:          params.Subject,
 		PlainTextContent: params.Text,
 		HTMLContent:      params.Html,
@@ -83,20 +77,20 @@ var _ = pubsub.NewSubscription(
 // https://encore.dev/docs/primitives/pubsub
 func sendEmail(ctx context.Context, event *EmailPreparedEvent) error {
 	// Creating an email
-	message := mail.NewSingleEmail(&event.From, event.Subject, &event.To, event.PlainTextContent, event.HTMLContent)
+	email := mail.NewSingleEmail(&event.From, event.Subject, &event.To, event.PlainTextContent, event.HTMLContent)
 	// Skipping sending an email in a non-production environment
 	if encore.Meta().Environment.Type != encore.EnvProduction {
 		rlog.Info(
 			"email sending was skipped in a non-production environment.",
-			"env:", encore.Meta().Environment.Type,
-			"message:", message)
+			"env", encore.Meta().Environment.Type,
+			"email", email)
 		return nil
 	}
 
 	// Creating a client using an API key
 	client := sendgrid.NewSendClient(secrets.SendGridAPIKey)
 	// Sending and error handling
-	response, err := client.SendWithContext(ctx, message)
+	response, err := client.SendWithContext(ctx, email)
 	if err != nil {
 		rlog.Error(err.Error())
 		return err

--- a/bits/sendgrid/sendgrid.go
+++ b/bits/sendgrid/sendgrid.go
@@ -82,8 +82,7 @@ func sendEmail(ctx context.Context, event *EmailPreparedEvent) error {
 	if encore.Meta().Environment.Type != encore.EnvProduction {
 		rlog.Info(
 			"skipping sending email in non-production environment",
-			"env", encore.Meta().Environment.Type,
-			"email", email)
+			"env", encore.Meta().Environment.Type)
 		return nil
 	}
 

--- a/bits/sendgrid/sendgrid.go
+++ b/bits/sendgrid/sendgrid.go
@@ -1,0 +1,101 @@
+package sendgrid
+
+import (
+	"context"
+
+	"encore.dev/beta/errs"
+	"encore.dev/pubsub"
+	"encore.dev/rlog"
+	"github.com/sendgrid/sendgrid-go"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+)
+
+// Encore docs about secrets: https://encore.dev/docs/primitives/secrets
+var secrets struct {
+	SendGridAPIKey string
+}
+
+type SendParams struct {
+	From struct {
+		Name    string `json:"name,omitempty"`
+		Address string `json:"address"`
+	} `json:"from"`
+	To struct {
+		Name    string `json:"name,omitempty"`
+		Address string `json:"address"`
+	} `json:"to"`
+	Subject string `json:"subject"`
+	Text    string `json:"text"`
+	Html    string `json:"html"`
+}
+
+type SendResponse struct {
+	MessageID string `json:"message_id"`
+}
+
+// Send sends an email using the SendGrid API.
+// https://docs.sendgrid.com/api-reference/mail-send/mail-send
+//
+//encore:api public method=POST path=/sendgrid
+func Send(ctx context.Context, params *SendParams) (*SendResponse, error) {
+	// Preparing the data to create an email event ready to be sent
+	event := &EmailPreparedEvent{
+		From:             *mail.NewEmail(params.From.Name, params.From.Address),
+		To:               *mail.NewEmail(params.To.Name, params.To.Address),
+		Subject:          params.Subject,
+		PlainTextContent: params.Text,
+		HTMLContent:      params.Html,
+	}
+
+	// Publishing an event
+	messageID, err := Emails.Publish(ctx, event)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SendResponse{MessageID: messageID}, nil
+}
+
+type EmailPreparedEvent struct {
+	From             mail.Email
+	Subject          string
+	To               mail.Email
+	PlainTextContent string
+	HTMLContent      string
+}
+
+var Emails = pubsub.NewTopic[*EmailPreparedEvent]("emails", pubsub.TopicConfig{
+	DeliveryGuarantee: pubsub.AtLeastOnce,
+})
+
+// The maximum number of messages which will be processed and retry policy can be configured below.
+// https://pkg.go.dev/encore.dev/pubsub#SubscriptionConfig
+var _ = pubsub.NewSubscription(
+	Emails, "send-email",
+	pubsub.SubscriptionConfig[*EmailPreparedEvent]{
+		Handler: sendEmail,
+	},
+)
+
+// To sending email, PubSub is used to control concurrency and avoid DDoS Sendgrid API.
+// https://encore.dev/docs/primitives/pubsub
+func sendEmail(ctx context.Context, event *EmailPreparedEvent) error {
+	// Creating an email
+	message := mail.NewSingleEmail(&event.From, event.Subject, &event.To, event.PlainTextContent, event.HTMLContent)
+	// Creating a client using an API key
+	client := sendgrid.NewSendClient(secrets.SendGridAPIKey)
+	// Sending and error handling
+	response, err := client.SendWithContext(ctx, message)
+	if err != nil {
+		rlog.Error(err.Error())
+		return err
+	}
+
+	if response.StatusCode != 200 {
+		return &errs.Error{
+			Code:    errs.Internal,
+			Message: "failed to send email",
+		}
+	}
+	return nil
+}

--- a/bits/sendgrid/sendgrid.go
+++ b/bits/sendgrid/sendgrid.go
@@ -81,7 +81,7 @@ func sendEmail(ctx context.Context, event *EmailPreparedEvent) error {
 	// Skipping sending an email in a non-production environment
 	if encore.Meta().Environment.Type != encore.EnvProduction {
 		rlog.Info(
-			"email sending was skipped in a non-production environment.",
+			"skipping sending email in non-production environment",
 			"env", encore.Meta().Environment.Type,
 			"email", email)
 		return nil

--- a/bits/sendgrid/sendgrid.go
+++ b/bits/sendgrid/sendgrid.go
@@ -17,12 +17,17 @@ var secrets struct {
 	SendGridAPIKey string
 }
 
+type Address struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
 type SendParams struct {
-	From    string `json:"form"` // sender email address
-	To      string `json:"to"`   // recipient email address
-	Subject string `json:"subject"`
-	Text    string `json:"text"`
-	Html    string `json:"html"`
+	From    Address `json:"from"` // sender email address
+	To      Address `json:"to"`   // recipient email address
+	Subject string  `json:"subject"`
+	Text    string  `json:"text"`
+	Html    string  `json:"html"`
 }
 
 type SendResponse struct {
@@ -36,8 +41,8 @@ type SendResponse struct {
 func Send(ctx context.Context, params *SendParams) (*SendResponse, error) {
 	// Preparing the data to create an email event ready to be sent
 	event := &EmailPreparedEvent{
-		From:             mail.Email{Address: params.From},
-		To:               mail.Email{Address: params.To},
+		From:             *mail.NewEmail(params.From.Name, params.From.Email),
+		To:               *mail.NewEmail(params.To.Name, params.To.Email),
 		Subject:          params.Subject,
 		PlainTextContent: params.Text,
 		HTMLContent:      params.Html,

--- a/bits/sendgrid/sendgrid.go
+++ b/bits/sendgrid/sendgrid.go
@@ -2,6 +2,7 @@ package sendgrid
 
 import (
 	"context"
+	"net/http"
 
 	"encore.dev/beta/errs"
 	"encore.dev/pubsub"
@@ -91,7 +92,7 @@ func sendEmail(ctx context.Context, event *EmailPreparedEvent) error {
 		return err
 	}
 
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		return &errs.Error{
 			Code:    errs.Internal,
 			Message: "failed to send email",


### PR DESCRIPTION
**Bits:** Added an example of using the SendGrid API using Pub/Sub to send emails asynchronously with the ability to control concurrency and retry policies.