### PR TITLE
Fix: Update await query in getPreviousMeasurement

### DIFF
--- a/uptime-ts/monitor/check.ts
+++ b/uptime-ts/monitor/check.ts
@@ -34,7 +34,7 @@ async function doCheck(site: Site): Promise<void> {
 }
 
 async function getPreviousMeasurement(siteID: number): Promise<boolean> {
-  const row = MonitorDB.queryRow`
+  const row = await MonitorDB.queryRow`
     SELECT up FROM checks
     WHERE site_id = ${siteID}
     ORDER BY checked_at DESC


### PR DESCRIPTION
Update asynchronous `queryRow` call in the [`uptime-ts`](https://github.com/encoredev/examples/blob/main/uptime-ts/monitor/check.ts#L36-L44) template.

https://github.com/encoredev/examples/blob/ecfdea675c8fedfee8e672053a97d75aa9285e25/uptime-ts/monitor/check.ts#L36-L44