### PR TITLE
fix: issue making GraphQL Apollo Sandbox inaccessible with TypeScript

### DIFF
--- a/ts/graphql/graphql/graphql.ts
+++ b/ts/graphql/graphql/graphql.ts
@@ -1,4 +1,5 @@
 import { api } from "encore.dev/api";
+import log from "encore.dev/log";
 import { ApolloServer, HeaderMap } from "@apollo/server";
 import { readFileSync } from "node:fs";
 import resolvers from "./resolvers";
@@ -25,12 +26,20 @@ export const graphqlAPI = api.raw(
       }
     }
 
+    let body: unknown;
+
+    try {
+      body = await json(req);
+    } catch (error) {
+      log.error(error);
+    }
+
     // More on how to use executeHTTPGraphQLRequest: https://www.apollographql.com/docs/apollo-server/integrations/building-integrations/
     const httpGraphQLResponse = await server.executeHTTPGraphQLRequest({
       httpGraphQLRequest: {
         headers,
         method: req.method!.toUpperCase(),
-        body: await json(req),
+        body,
         search: new URLSearchParams(req.url ?? "").toString(),
       },
       context: async () => {


### PR DESCRIPTION
This fixes: #154

My guess here is that when the request to `http://127.0.0.1:4000/graphql` is made by the browser, it reaches the server as a GET request with no request body causing the conversion to JSON to fail. 

![image](https://github.com/user-attachments/assets/46a13408-12d3-4564-b9e7-dc5643570fe4)
