### PR TITLE
fix(ts/clerk): add clerkSecretKey() to verifyToken() options

### DIFF
--- a/ts/clerk/auth/auth.ts
+++ b/ts/clerk/auth/auth.ts
@@ -34,6 +34,7 @@ const myAuthHandler = authHandler(async (params: AuthParams): Promise<
   try {
     const result = await verifyToken(token, {
       authorizedParties: AUTHORIZED_PARTIES,
+      secretKey: clerkSecretKey(),
     });
 
     const user = await clerkClient.users.getUser(result.sub);


### PR DESCRIPTION
it fix the error caused by this code:

https://github.com/clerk/javascript/blob/0fa449cd09c9973297464a14f785895e3ddcab4d/packages/backend/src/tokens/verify.ts#L43