### PR TITLE
fix link to Templates page in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Follow these steps to submit a **Starter**:
 3. Include a `README.md` with instructions for how to use the template. We recommend
    following [this format](https://github.com/encoredev/examples/blob/8c7e33243f6bfb1b2654839e996e9a924dcd309e/uptime/README.md).
 
-Once your Pull Request has been approved, it may be featured on the [Templates page](/templates) on the Encore website.
+Once your Pull Request has been approved, it may be featured on the [Templates page](https://encore.dev/templates) on the Encore website.
 
 ### Submitting Bits
 
@@ -131,7 +131,7 @@ Follow these steps to submit your **Bits**:
    as your template will soon be installable via the CLI.
 3. Include a `README.md` with instructions for how to use the template.
 
-Once your Pull Request has been approved, it may be featured on the [Templates page](/templates) on the Encore website.
+Once your Pull Request has been approved, it may be featured on the [Templates page](https://encore.dev/templates) on the Encore website.
 
 ### Dynamic Encore AppID
 


### PR DESCRIPTION
Link to Template pages redirects to - https://github.com/encoredev/examples/blob/main/templates

![image](https://github.com/user-attachments/assets/ff709150-105d-48d2-97da-4c8a9fa8c317)

I assume we correctly want it to link to this page on the encore website - https://encore.dev/templates

![image](https://github.com/user-attachments/assets/f6d70dea-1e17-47cb-a9b0-515ab04a9844)

